### PR TITLE
feat(typedobject): improve to create the type method

### DIFF
--- a/TypedObject.test.ts
+++ b/TypedObject.test.ts
@@ -10,7 +10,7 @@ import { JSONish } from "./JSONish";
 describe("createTypedObject", () => {
   test("createTypedObject(%p) is %p", () => {
     type Sample = TypedObject<"Sample", string>;
-    const result = createTypedObject<Sample>("Sample", "sample value");
+    const result: Sample = createTypedObject("Sample", "sample value");
     expect(result).toEqual({
       _t: "Sample",
       _v: "sample value",

--- a/TypedObject.ts
+++ b/TypedObject.ts
@@ -7,8 +7,6 @@ import keys from "lodash/keys";
 import { JSONish } from "./JSONish";
 import { isPrimitiveObject } from "./PrimitiveObject";
 
-type GetType<T> = T extends TypedObject<infer U1, infer U2> ? [U1, U2] : never;
-
 export type TypedObject<N extends string, T extends JSONish> = {
   /** type name */
   _t: N;
@@ -16,10 +14,21 @@ export type TypedObject<N extends string, T extends JSONish> = {
   _v: T;
 };
 
-export function createTypedObject<T extends TypedObject<any, any>>(
-  name: GetType<T>[0],
-  value: GetType<T>[1],
-): TypedObject<GetType<T>[0], GetType<T>[1]> {
+/**
+ * To create TypedObject
+ *
+ * ```
+ * type Sample = TypedObject<"Sample", string>;
+ * const result: Sample = createTypedObject("Sample", "sample value");
+ * ```
+ *
+ * @param name String literal
+ * @param value
+ */
+export function createTypedObject<N extends string, T extends JSONish>(
+  name: N,
+  value: T,
+): TypedObject<N, T> {
   return { _t: name, _v: value };
 }
 


### PR DESCRIPTION
TypeScriptとしてランタイム時の型は保証されないので、`createTypedObject` の受け取り時に期待する型を指定する方法に変更しました.